### PR TITLE
robot: increase test run time for the queue type tests to 60s

### DIFF
--- a/queue_types_ag.robot
+++ b/queue_types_ag.robot
@@ -19,7 +19,7 @@ Test Queue Types AG
 
     # Run application
     Start Process    ${application} ${SPACE} -c ${SPACE} ${core_mask} ${SPACE} -${mode}    stderr=STDOUT    shell=True    alias=app
-    Sleep    25s
+    Sleep    60s
 
     # Terminate application
     Send Signal To Process    SIGINT    app    group=true

--- a/queue_types_local.robot
+++ b/queue_types_local.robot
@@ -22,7 +22,7 @@ Test Queue Types Local
 
     # Run application
     Start Process    ${application} ${SPACE} -c ${SPACE} ${core_mask} ${SPACE} -${mode}    stderr=STDOUT    shell=True    alias=app
-    Sleep    25s
+    Sleep    60s
 
     # Terminate application
     Send Signal To Process    SIGINT    app    group=true


### PR DESCRIPTION
The tests queue_types_ag and queue_types_local sometimes need to run a bit
longer to have time to print measurement data before being stopped.

Increase the robot test runtime from 25s to 60s.