### PR TITLE
robot: increase performance test run time to 60s

### DIFF
--- a/loop.robot
+++ b/loop.robot
@@ -19,7 +19,7 @@ Test Loop
 
     # Run application
     Start Process    ${application} ${SPACE} -c ${SPACE} ${core_mask} ${SPACE} -${mode}    stderr=STDOUT    shell=True    alias=app
-    Sleep    25s
+    Sleep    60s
 
     # Terminate application
     Send Signal To Process    SIGINT    app    group=true

--- a/ordered.robot
+++ b/ordered.robot
@@ -20,7 +20,7 @@ Test Ordered
 
     # Run application
     Start Process    ${application} ${SPACE} -c ${SPACE} ${core_mask} ${SPACE} -${mode}    stderr=STDOUT    shell=True    alias=app
-    Sleep    25s
+    Sleep    60s
 
     # Terminate application
     Send Signal To Process    SIGINT    app    group=true

--- a/pairs.robot
+++ b/pairs.robot
@@ -19,7 +19,7 @@ Test Pairs
 
     # Run application
     Start Process    ${application} ${SPACE} -c ${SPACE} ${core_mask} ${SPACE} -${mode}    stderr=STDOUT    shell=True    alias=app
-    Sleep    25s
+    Sleep    60s
 
     # Terminate application
     Send Signal To Process    SIGINT    app    group=true

--- a/queue_group.robot
+++ b/queue_group.robot
@@ -26,7 +26,7 @@ Test Queue Group
 
     # Run application
     Start Process    ${application} ${SPACE} -c ${SPACE} ${core_mask} ${SPACE} -${mode}    stderr=STDOUT    shell=True    alias=app
-    Sleep    25s
+    Sleep    60s
 
     # Terminate application
     Send Signal To Process    SIGINT    app    group=true

--- a/queue_groups.robot
+++ b/queue_groups.robot
@@ -19,7 +19,7 @@ Test Queue Groups
 
     # Run application
     Start Process    ${application} ${SPACE} -c ${SPACE} ${core_mask} ${SPACE} -${mode}    stderr=STDOUT    shell=True    alias=app
-    Sleep    25s
+    Sleep    60s
 
     # Terminate application
     Send Signal To Process    SIGINT    app    group=true


### PR DESCRIPTION
The performance  tests sometimes need to run a bit longer to have time
to print measurement data before being stopped.

Increase the robot test runtime from 25s to 60s.