### PR TITLE
robot: POOL_STATISTICS_MATCH regexp updated

### DIFF
--- a/common.robot
+++ b/common.robot
@@ -7,7 +7,7 @@ Library    String
 
 *** Variables ***
 # Match pool statistics
-@{pool_statistics_match} =    (buf|pkt)\\s*[0-9]+\\s*[0-9]+(\\s*[0-3]+:\\[sz=[0-9]+\\s*n=[0-9]+\\(0/[0-9]+\\)\\s*\\$=[0-9]+\\])+
+@{pool_statistics_match} =    (buf|pkt)(\\s*[0-9]+)+(\\s*[0-3]+:\\[sz=[0-9]+\\s*n=[0-9]+\\(0/[0-9]+\\)\\s*\\$=[0-9]+\\])+
 
 # List of return codes
 @{rc_list} =    ${0}    ${-2}    ${-9}


### PR DESCRIPTION
The event user area size is included in the pool statistics printout,
the regexp needs chage accordingly ("uarea" + size added).

Old printout:
EM Event Pools: 1
-----------------
id name type offset sizes [size count(used/free) cache]
0x1 default buf 00 04 0:[sz=256 n=16384(0/16384) $=64] ...

New printout:
EM Event Pools: 1
-----------------
id name type offset uarea sizes [size count(used/free) cache]
0x1 default buf 00 00 04 0:[sz=256 n=16384(0/16384) $=64] ...